### PR TITLE
Corrected buffer overflow on register

### DIFF
--- a/src/communication/incoming/register/REGISTER.h
+++ b/src/communication/incoming/register/REGISTER.h
@@ -12,7 +12,7 @@ typedef struct register_context_s {
     char username[255];
     char password[255];
     char figure[255];
-    char gender[1];
+    char gender[2];
     session *player;
 } register_context;
 


### PR DESCRIPTION
There was a buffer overflow on register in the function `async_register:42` at `strcpy(ctx->gender, gender);`

My guess is that strcpy actually put `\0` at the end of the string when copying. The size of `gender` being `1`, it resulted in a buffer overflow error.

This fix patches this issue.

