### PR TITLE
Messenger search shouldn't use LIKE clause

### DIFF
--- a/Kepler-Server/src/main/java/org/alexdev/kepler/dao/mysql/MessengerDao.java
+++ b/Kepler-Server/src/main/java/org/alexdev/kepler/dao/mysql/MessengerDao.java
@@ -111,8 +111,8 @@ public class MessengerDao {
 
         try {
             sqlConnection = Storage.getStorage().getConnection();
-            preparedStatement = Storage.getStorage().prepare("SELECT id FROM users WHERE username LIKE ? LIMIT 30", sqlConnection);
-            preparedStatement.setString(1, query + "%");
+            preparedStatement = Storage.getStorage().prepare("SELECT id FROM users WHERE username = ? LIMIT 30", sqlConnection);
+            preparedStatement.setString(1, query);
 
             resultSet = preparedStatement.executeQuery();
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.2'
 services:
     kepler:
-        image: ewout/kepler:0.1.29
+        image: ewout/kepler:0.1.30
         restart: always
         environment:
             MYSQL_HOST: mariadb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.2'
 services:
     kepler:
-        image: ewout/kepler:0.1.27
+        image: ewout/kepler:0.1.28
         restart: always
         environment:
             MYSQL_HOST: mariadb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.2'
 services:
     kepler:
-        image: ewout/kepler:0.1.28
+        image: ewout/kepler:0.1.29
         restart: always
         environment:
             MYSQL_HOST: mariadb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.2'
 services:
     kepler:
-        image: ewout/kepler:0.1.30
+        image: ewout/kepler:0.1.31
         restart: always
         environment:
             MYSQL_HOST: mariadb


### PR DESCRIPTION
Leads to wrong user being returned. In this version the messenger only returns one user, using the LIKE clause leads to unexpected behaviour. 