### PR TITLE
Fixed "exception in selector loop" on Linux

### DIFF
--- a/Kepler-Server/build.gradle
+++ b/Kepler-Server/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation group: 'org.mariadb.jdbc', name: 'mariadb-java-client', version: '2.3.0'
 
     // https://mvnrepository.com/artifact/io.netty/netty-all
-    implementation group: 'io.netty', name: 'netty-all', version: '4.1.32.Final'
+    implementation group: 'io.netty', name: 'netty-all', version: '4.1.5.Final'
 
     // https://mvnrepository.com/artifact/org.slf4j/slf4j-api
     implementation group: 'org.slf4j', name: 'slf4j-api', version: '1.7.25'


### PR DESCRIPTION
Fixed unexpected exception in the selector loop on Linux by upgrading netty in gradle settings.
I upgraded netty to 4.1.5.Final version to fix the follow error on Linux.

```
WARN  [io.netty.channel.epoll.EpollEventLoop] - Unexpected exception in the selector loop.
java.lang.NoSuchMethodError: io.netty.channel.epoll.EpollEventLoop.deadlineNanos()J
  at io.netty.channel.epoll.EpollEventLoop.epollWait(EpollEventLoop.java:243)
  at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:278)
  at io.netty.util.concurrent.SingleThreadEventExecutor$5.run(SingleThreadEventExecutor.java:886)
  at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
  at java.base/java.lang.Thread.run(Thread.java:844)
```
