### PR TITLE
Harden and optimize Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,7 @@ LICENSE.txt
 README.md
 .github
 .vscode
+.gradle/
+build/
+Kepler-Server/build/
+Kepler-Server/.gradle/

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,4 +47,7 @@ COPY --from=build --chown=kepler:kepler /kepler/build ./
 
 USER kepler
 
+HEALTHCHECK --interval=10s --timeout=5s --start-period=15s --retries=3 \
+  CMD cat /proc/net/tcp /proc/net/tcp6 2>/dev/null | grep -q ":$(printf '%04X' ${SERVER_PORT:-12321}) "
+
 CMD ["sh", "run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM alpine:3.20 AS base
 
 # Add OpenJDK17
-RUN apk add --no-cache openjdk17=17.0.12_p7-r0
+RUN apk add --no-cache openjdk17
 
 # Uses /kepler directory
 WORKDIR /kepler
@@ -17,7 +17,7 @@ WORKDIR /kepler
 FROM base AS build
 
 # Add unzip
-RUN apk add --no-cache unzip=6.0-r14
+RUN apk add --no-cache unzip
 
 # Copy every files/folders that are not in .dockerignore
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # BUILD STAGE #
 ###############
 
-FROM alpine:3.20 AS build
+FROM alpine:3.23 AS build
 
 RUN apk add --no-cache openjdk17 unzip
 
@@ -35,7 +35,7 @@ RUN sed -i 's/\r$//' tools/scripts/run.sh && \
 # PRODUCTION STAGE #
 ####################
 
-FROM alpine:3.20
+FROM alpine:3.23
 
 RUN apk add --no-cache openjdk17-jre-headless && \
     addgroup -S kepler && adduser -S kepler -G kepler && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,41 +1,31 @@
-##############
-# BASE STAGE #
-##############
-
-FROM alpine:3.20 AS base
-
-# Add OpenJDK17
-RUN apk add --no-cache openjdk17
-
-# Uses /kepler directory
-WORKDIR /kepler
-
 ###############
 # BUILD STAGE #
 ###############
 
-FROM base AS build
+FROM alpine:3.20 AS build
 
-# Add unzip
-RUN apk add --no-cache unzip
+RUN apk add --no-cache openjdk17 unzip
 
-# Copy every files/folders that are not in .dockerignore
+WORKDIR /kepler
+
+# Copy only build configuration first for better layer caching
+COPY gradlew settings.gradle ./
+COPY gradle/ gradle/
+COPY Kepler-Server/build.gradle Kepler-Server/build.gradle
+
+# Fix line endings, make executable, and cache Gradle dependencies
+RUN sed -i 's/\r$//' gradlew && \
+    chmod +x gradlew && \
+    ./gradlew --no-daemon dependencies
+
+# Copy the rest of the source code
 COPY . .
 
-# Convert CRLF to LF executable files (failing build for Windows without this)
-RUN sed -i 's/\r$//' gradlew tools/scripts/run.sh
-
-# Make gradlew and run.sh executable
-RUN chmod +x gradlew tools/scripts/run.sh
-
-# Run gradle build
-RUN ./gradlew distZip
-
-# Unzip builded Kepler server
-RUN unzip -qq ./Kepler-Server/build/distributions/Kepler-Server.zip -d ./release
-
-# Prepare build directory
-RUN rm -rf ./release/Kepler-Server/bin && \
+# Build and prepare the distribution
+RUN sed -i 's/\r$//' tools/scripts/run.sh && \
+    ./gradlew --no-daemon distZip && \
+    unzip -qq ./Kepler-Server/build/distributions/Kepler-Server.zip -d ./release && \
+    rm -rf ./release/Kepler-Server/bin && \
     mkdir -p ./build/lib && \
     mv ./release/Kepler-Server/lib/Kepler-Server.jar ./build/kepler.jar && \
     mv ./release/Kepler-Server/lib/* ./build/lib && \
@@ -45,9 +35,16 @@ RUN rm -rf ./release/Kepler-Server/bin && \
 # PRODUCTION STAGE #
 ####################
 
-FROM base AS production
+FROM alpine:3.20
 
-# Copy builded Kepler server
-COPY --from=build /kepler/build ./
+RUN apk add --no-cache openjdk17-jre-headless && \
+    addgroup -S kepler && adduser -S kepler -G kepler && \
+    mkdir /kepler && chown kepler:kepler /kepler
 
-CMD [ "sh", "run.sh" ]
+WORKDIR /kepler
+
+COPY --from=build --chown=kepler:kepler /kepler/build ./
+
+USER kepler
+
+CMD ["sh", "run.sh"]

--- a/compose.yml
+++ b/compose.yml
@@ -10,7 +10,6 @@ services:
         condition: service_healthy
     ports:
       - "${SERVER_PORT}:${SERVER_PORT}"
-      - "${RCON_PORT}:${RCON_PORT}"
       - "${MUS_PORT}:${MUS_PORT}"
   mariadb:
     image: mariadb:11.4

--- a/dev.compose.yml
+++ b/dev.compose.yml
@@ -1,0 +1,57 @@
+services:
+  kepler:
+    build: .
+    container_name: kepler
+    restart: unless-stopped
+    env_file:
+      - .env
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    ports:
+      - "${SERVER_PORT}:${SERVER_PORT}"
+      - "${RCON_PORT}:${RCON_PORT}"
+      - "${MUS_PORT}:${MUS_PORT}"
+    develop:
+      watch:
+        - action: rebuild
+          path: Kepler-Server/src
+        - action: rebuild
+          path: Kepler-Server/build.gradle
+        - action: rebuild
+          path: settings.gradle
+        - action: rebuild
+          path: gradle
+        - action: rebuild
+          path: gradlew
+        - action: rebuild
+          path: tools/scripts/run.sh
+        - action: rebuild
+          path: Dockerfile
+  mariadb:
+    image: mariadb:11.4
+    container_name: mariadb
+    restart: unless-stopped
+    env_file:
+      - .env
+    volumes:
+      - mariadb:/var/lib/mysql
+      - ./tools/kepler.sql:/docker-entrypoint-initdb.d/kepler.sql
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      start_period: 10s
+      interval: 10s
+      timeout: 5s
+      retries: 3
+  phpmyadmin:
+    image: phpmyadmin
+    container_name: phpmyadmin
+    restart: always
+    ports:
+      - 8080:80
+    environment:
+      - PMA_ARBITRARY=1
+
+volumes:
+  mariadb:
+    name: kepler-mariadb

--- a/tools/scripts/run.sh
+++ b/tools/scripts/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 CLASSPATH=kepler.jar:lib/HikariCP-3.4.1.jar:lib/mariadb-java-client-2.3.0.jar:lib/netty-all-4.1.33.Final.jar:lib/slf4j-log4j12-1.7.25.jar:lib/slf4j-api-1.7.25.jar:lib/log4j-1.2.17.jar:lib/commons-configuration2-2.2.jar:lib/commons-lang3-3.9.jar:lib/commons-lang-2.6.jar:lib/commons-validator-1.6.jar:lib/gson-2.8.0.jar:lib/spring-security-crypto-5.7.3.jar:lib/bcprov-jdk15on-1.70.jar:lib/chesslib-1.1.1.jar:lib/commons-beanutils-1.9.2.jar:lib/commons-logging-1.2.jar:lib/commons-digester-1.8.1.jar:lib/commons-collections-3.2.2.jar
 
-java -classpath $CLASSPATH org.alexdev.kepler.Kepler
+exec java -classpath $CLASSPATH org.alexdev.kepler.Kepler


### PR DESCRIPTION
 ## Summary
  - Upgrade Alpine base image from 3.20 to 3.23
  - Switch production stage from full JDK to JRE-headless, reducing image size                                                               
  - Run as non-root kepler user instead of root
  - Split COPY into build config first, then source code, for better Docker layer caching (dependency downloads are cached unless build      
  config changes)                                                                                                                          
  - Expand .dockerignore to exclude .gradle/ and build/ directories
  - Remove pinned package versions for simpler maintenance
  - Consolidate RUN layers to reduce image layer count
  - Add container healthcheck probing the game server port
  - Prefix java command with exec for graceful shutdown (SIGTERM reaches PID 1, shutdown hook saves player state)
  - Remove RCON port exposure from production compose.yml
  - Add dev.compose.yml with Docker Compose watch mode (auto-rebuild on source changes) and phpMyAdmin