### PR TITLE
Fix race condition in GameScheduler causing NullPointerException at startup

### DIFF
--- a/Kepler-Server/src/main/java/org/alexdev/kepler/game/GameScheduler.java
+++ b/Kepler-Server/src/main/java/org/alexdev/kepler/game/GameScheduler.java
@@ -37,10 +37,10 @@ public class GameScheduler implements Runnable {
 
     private GameScheduler() {
         this.schedulerService = createNewScheduler();
-        this.gameScheduler = this.schedulerService.scheduleAtFixedRate(this, 0, 1, TimeUnit.SECONDS);
         this.creditsHandoutQueue = new LinkedBlockingQueue<>();
         this.itemSavingQueue = new LinkedBlockingDeque<>();
         this.itemDeletionQueue = new LinkedBlockingDeque<>();
+        this.gameScheduler = this.schedulerService.scheduleAtFixedRate(this, 0, 1, TimeUnit.SECONDS);
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
## Summary                                                                                                                                                                             
  - Fix a race condition in `GameScheduler` where `scheduleAtFixedRate` could fire the `run()`                                                                                           
    method before the queues (`creditsHandoutQueue`, `itemSavingQueue`, `itemDeletionQueue`)                                                                                             
    were initialized, causing a NullPointerException at startup                                                                                                                          
  - Moved the scheduler start to after all fields are initialized
  
This bug did not appear all the time :
  
```bash
kepler      | java.lang.NullPointerException: Cannot invoke "java.util.concurrent.BlockingQueue.drainTo(java.util.Collection)" because "this.creditsHandoutQueue" is null
kepler      |   at org.alexdev.kepler.game.GameScheduler.run(GameScheduler.java:88)
kepler      |   at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
kepler      |   at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:305)
kepler      |   at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
kepler      |   at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
kepler      |   at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
kepler      |   at java.base/java.lang.Thread.run(Thread.java:840)
```